### PR TITLE
Add support for bundling everything in docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DOCKER_REPO="docker-local-isg.artifactory.it.keysight.com"
+docker build --tag $DOCKER_REPO/tiger/pan-demo-tool:local "$@" -f docker/Dockerfile .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM docker-remote.artifactorylbj.it.keysight.com/debian:12-slim
+RUN apt update && apt install -y python3 python3-pip python3-venv git gpg wget lsb-release
+RUN wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+    https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" \
+    | tee /etc/apt/sources.list.d/hashicorp.list
+RUN apt update && apt install -y terraform
+WORKDIR /pan-demo
+COPY ./requirements.txt /pan-demo/requirements.txt
+RUN DISABLE_CACHE=1 git clone "https://bitbucket.it.keysight.com/scm/isgappsec/cyperf-api-wrapper.git"
+RUN python3 -m venv /pan-demo/py3 && \
+    . /pan-demo/py3/bin/activate && \
+    pip install --no-cache --upgrade pip setuptools wheel && \
+    pip install --no-cache -U -r requirements.txt && \
+    pip install --no-cache ./cyperf-api-wrapper
+COPY . .
+RUN chmod +x ./entrypoint.sh && \
+    ./entrypoint.sh
+RUN mkdir -p /temp/terraform && \
+    cp -r terraform/.terraform /temp/.terraform && \
+    cp terraform/.terraform.lock.hcl /temp/
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+. /pan-demo/py3/bin/activate
+cp -r /temp/.terraform /pan-demo/terraform/
+cp /temp/.terraform.lock.hcl /pan-demo/terraform/
+python3 pan_demo_setup.py "$@"

--- a/pan_demo_setup.py
+++ b/pan_demo_setup.py
@@ -219,12 +219,19 @@ class CyPerfUtils(object):
 class Deployer(object):
     def __init__(self):
         self.terraform_dir             = './terraform'
+        self.terraform_state_dir       = './terraform-state'
 
         self.controller_admin_user     = 'admin'
         self.controller_admin_password = 'CyPerf&Keysight#1'
 
         self.license_server_user       = self.controller_admin_user
         self.license_server_password   = self.controller_admin_password
+
+        self.terraform_state_files     = ['.terraform',
+                                          'terraform.tfvars',
+                                          'terraform.tfstate',
+                                          'terraform.tfstate.backup',
+                                          '.terraform.lock.hcl']
 
     def _get_utils(self, terraform_output, eula_accept_interactive=True):
         if 'mdw_detail' in terraform_output:
@@ -255,19 +262,44 @@ class Deployer(object):
 
     def terraform_initialize(self):
         # Initialize Terraform
-        subprocess.run(['terraform', f'-chdir={self.terraform_dir}',  'init'], check=True)
+        subprocess.run(['terraform', f'-chdir={self.terraform_dir}',  'init'],
+                       check=True)
 
+        # Populate expected terraform files from terraform state dir
+        subprocess.run(['mkdir', '-p', self.terraform_state_dir])
+        if not os.path.exists(f'{self.terraform_state_dir}/terraform.tfvars'):
+            subprocess.run(['cp', 'terraform.tfvars', self.terraform_state_dir])
+        for tf_state_file in self.terraform_state_files:
+            if os.path.exists(f'{self.terraform_state_dir}/{tf_state_file}'):
+                subprocess.run(['cp', '-r',
+                                f'{self.terraform_state_dir}/{tf_state_file}',
+                                f'{self.terraform_dir}/{tf_state_file}'],
+                               check=False)
+         
     def terraform_deploy(self):
-        # cp tfvars inside ./terraform
-        subprocess.run(['cp', 'terraform.tfvars', f'{self.terraform_dir}'], check=True)
-
-        # Apply Terraform configuration
-        subprocess.run(['terraform', f'-chdir={self.terraform_dir}', 'apply', '-auto-approve'], check=True)
+        try:
+            # Apply Terraform configuration
+            subprocess.run(['terraform',
+                            f'-chdir={self.terraform_dir}',
+                            'apply',
+                            '-auto-approve'], check=True)
+        finally:
+            # persist Terraform state to terraform state dir
+            for tf_state_file in self.terraform_state_files:
+                subprocess.run(['cp', '-r',
+                                f'{self.terraform_dir}/{tf_state_file}',
+                                f'{self.terraform_state_dir}/{tf_state_file}'],
+                               check=False)
 
     def collect_terraform_output(self):
         # Capture the output in JSON format
-        result = subprocess.run(['terraform', f'-chdir={self.terraform_dir}', 'output', '-json'], capture_output=True, text=True, check=True)
-        
+        result = subprocess.run(['terraform',
+                                 f'-chdir={self.terraform_dir}',
+                                 'output',
+                                 '-json'],
+                                capture_output=True,
+                                text=True,
+                                check=True)
         # Parse the JSON output
         terraform_output = json.loads(result.stdout)
 
@@ -275,18 +307,20 @@ class Deployer(object):
 
     def terraform_destroy(self):
         # copy tfvars inside ./terraform again, the aws key information might have changed
-        subprocess.run(['cp', 'terraform.tfvars', f'{self.terraform_dir}'], check=True)
+        subprocess.run(['cp', 'terraform.tfvars', f'{self.terraform_dir}'],
+                       check=True)
 
         # Destroy Terraform configuration
         subprocess.run(['terraform', f'-chdir={self.terraform_dir}', 'destroy', '-auto-approve'], check=True)
 
         # Remove all temporary files
-        subprocess.run(['rm', '-f',  f'{self.terraform_dir}/terraform.tfvars'], check=False)
-        subprocess.run(['rm', '-f',  f'{self.terraform_dir}/terraform.tfstate'], check=False)
-        subprocess.run(['rm', '-f',  f'{self.terraform_dir}/terraform.tfstate.backup'], check=False)
-        subprocess.run(['rm', '-f',  f'{self.terraform_dir}/.terraform.lock.hcl'], check=True)
-        subprocess.run(['rm', '-rf', f'{self.terraform_dir}/.terraform/'], check=True)
-        subprocess.run(['rm', '-f',  f'terraform.tfstate'], check=False)
+        for tf_state_file in self.terraform_state_files:
+            subprocess.run(['rm', '-rf',
+                            f'{self.terraform_dir}/{tf_state_file}'],
+                           check=False)
+            subprocess.run(['rm', '-rf',
+                            f'{self.terraform_state_dir}/{tf_state_file}'],
+                           check=False)
 
     def initialize(self, args):
         self.terraform_initialize()

--- a/pan_demo_setup.sh
+++ b/pan_demo_setup.sh
@@ -2,14 +2,11 @@
 
 DOCKER_REPO="docker-local-isg.artifactory.it.keysight.com"
 CURRENT_DIR="$(pwd)"
-mkdir -p $CURRENT_DIR/.terraform
-touch $CURRENT_DIR/terraform.tfstate
-touch $CURRENT_DIR/terraform.tfstate.backup
-touch $CURRENT_DIR/terraform.tfvars
+mkdir -p terraform-state/.terraform
+touch terraform-state/terraform.tfstate
+touch terraform-state/terraform.tfstate.backup
+cp terraform.tfvars terraform-state/terraform.tfvars
 docker login $DOCKER_REPO
 docker run --rm -it \
-       -v $CURRENT_DIR/terraform.tfvars:/pan-demo/terraform.tfvars \
-       -v $CURRENT_DIR/terraform.tfstate:/pan-demo/terraform/terraform.tfstate \
-       -v $CURRENT_DIR/terraform.tfstate.backup:/pan-demo/terraform/terraform.tfstate.backup \
-       -v $CURRENT_DIR/.terraform:/pan-demo/terraform/.terraform \
+       -v $CURRENT_DIR/terraform-state:/pan-demo/terraform-state \
        $DOCKER_REPO/tiger/pan-demo-tool:local "$@"

--- a/pan_demo_setup.sh
+++ b/pan_demo_setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DOCKER_REPO="docker-local-isg.artifactory.it.keysight.com"
+CURRENT_DIR="$(pwd)"
+mkdir -p $CURRENT_DIR/.terraform
+touch $CURRENT_DIR/terraform.tfstate
+touch $CURRENT_DIR/terraform.tfstate.backup
+touch $CURRENT_DIR/terraform.tfvars
+docker login $DOCKER_REPO
+docker run --rm -it \
+       -v $CURRENT_DIR/terraform.tfvars:/pan-demo/terraform.tfvars \
+       -v $CURRENT_DIR/terraform.tfstate:/pan-demo/terraform/terraform.tfstate \
+       -v $CURRENT_DIR/terraform.tfstate.backup:/pan-demo/terraform/terraform.tfstate.backup \
+       -v $CURRENT_DIR/.terraform:/pan-demo/terraform/.terraform \
+       $DOCKER_REPO/tiger/pan-demo-tool:local "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+urllib3


### PR DESCRIPTION
This PR adds support for creating a Docker container which includes this repo, a python env, the cyperf-api-wrapper, and an already-initialized terraform environment with the proper modules pre-installed. To pre-install these, I refactored pan_demo_setup.py a little bit to call the terraform initialize code separately from deploy() or destroy().

The container uses entrypoint.sh as the entrypoint, which is just a wrapper that pulls the base terraform env, prepares the Python env, and runs pan_demo_setup.py with any provided arguments.

The user is supposed to run the container using the pan_demo_setup.sh script, which mounts a few files locally, most importanly the terraform state and tfvars, and then calls the container with any provided arguments.

The container is currently published in the Tiger Artifactory repo, and requires docker login to be accessible. The goal is to publish it either to a PAN repo, or to our public ECR instance, but that can come later.

Finally, there is a build.sh script that calls docker build to create a new version of the container.