### PR TITLE
enhancement: route add, enable ip frwding, pan fw policy update

### DIFF
--- a/main-aws.tf
+++ b/main-aws.tf
@@ -744,6 +744,9 @@ resource "aws_networkfirewall_firewall_policy" "aws-ngfw" {
   stateful_rule_group_reference {
     priority = 5
     resource_arn = "arn:aws:network-firewall:${var.aws_region}:aws-managed:stateful-rulegroup/MalwareDomainsStrictOrder"
+    override {
+      action = "DROP_TO_ALERT"
+    }
   }
 
   stateful_rule_group_reference {

--- a/main-azure.tf
+++ b/main-azure.tf
@@ -317,6 +317,15 @@ resource "azurerm_route" "route_to_ngfw" {
   next_hop_in_ip_address = azurerm_firewall.azure-ngfw.ip_configuration[0].private_ip_address
 }
 
+resource "azurerm_route" "route_to_panfw" {
+  name                   = "${var.azure_stack_name}-route-to-panfw"
+  resource_group_name    = azurerm_resource_group.cyperfazuretest-rg.name
+  route_table_name       = azurerm_route_table.private_rt.name
+  address_prefix         = var.azure_srv_test_cidr_pan
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = "${module.azpanfw.panfw_detail.panfw_cli_private_ip}"
+}
+
 resource "azurerm_route" "route_to_ngfw1" {
   name                   = "${var.azure_stack_name}-route-to-ngfw1"
   resource_group_name    = azurerm_resource_group.cyperfazuretest-rg.name
@@ -324,6 +333,15 @@ resource "azurerm_route" "route_to_ngfw1" {
   address_prefix         = var.azure_cli_test_cidr
   next_hop_type          = "VirtualAppliance"
   next_hop_in_ip_address = azurerm_firewall.azure-ngfw.ip_configuration[0].private_ip_address
+}
+
+resource "azurerm_route" "route_to_panfw1" {
+  name                   = "${var.azure_stack_name}-route-to-panfw1"
+  resource_group_name    = azurerm_resource_group.cyperfazuretest-rg.name
+  route_table_name       = azurerm_route_table.private_rt_srv.name
+  address_prefix         = var.azure_cli_test_cidr_pan
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = "${module.azpanfw.panfw_detail.panfw_srv_private_ip}"
 }
 
 resource "azurerm_route" "route_igw_to_agent1" {

--- a/terraform/modules/azure_panfw/main.tf
+++ b/terraform/modules/azure_panfw/main.tf
@@ -34,7 +34,7 @@ resource "azurerm_network_interface" "az_panfw_cli_interface" {
     name                = "${var.azure_stack_name}-panfw-cli-interface"
     location            = var.azure_location
     resource_group_name = var.resource_group.resource_group_name
-
+    ip_forwarding_enabled = true
     ip_configuration {
         name                          = "primary"
         subnet_id                     = var.resource_group.client_subnet
@@ -53,7 +53,7 @@ resource "azurerm_network_interface" "az_panfw_srv_interface" {
     name                = "${var.azure_stack_name}-panfw-srv-interface"
     location            = var.azure_location
     resource_group_name = var.resource_group.resource_group_name
-
+    ip_forwarding_enabled = true
     ip_configuration {
         name                          = "primary"
         subnet_id                     = var.resource_group.server_subnet


### PR DESCRIPTION
This PR has the following fixes, which Bala requested
===================================
On Azure env (Fixes)
1. Add Routes in the below route tables - [@Kaushik Biswas](mailto:kaushik.biswas@keysight.com)
Route table private-rt (Client to server route)
Destination - [10.0.7.0/24](https://urldefense.com/v3/__http:/10.0.7.0/24__;!!I5pVk4LIGAfnvw!jpgoC_SGkQnLuLOpvE3YrDD7s2Xuv7vevRi_OdlKLf4iw91olCquahQW6THL0xatXXmHYn4e2US5-VJpj8CqjenBMFPx1CwV$), next hop type - Virtual Appliance, Next hop IP - 10.0.6.4 (This is the IP of the PANW FW)
Route table private-rt-srv  (Server to client route)
Destination - [10.0.6.0/24](https://urldefense.com/v3/__http:/10.0.6.0/24__;!!I5pVk4LIGAfnvw!jpgoC_SGkQnLuLOpvE3YrDD7s2Xuv7vevRi_OdlKLf4iw91olCquahQW6THL0xatXXmHYn4e2US5-VJpj8CqjenBMKz1gS3d$), next hop type - Virtual Appliance, Next hop IP - 10.0.7.4 (This is the IP of the PANW FW)
2. "Enable IP Forwarding" option needs to be enabled on both data interfaces of PANW NGFW. - [@Kaushik Biswas](mailto:kaushik.biswas@keysight.com)

6. On the Azure Firewall Policy, in the private IP ranges section - Perform SNAT - "for all IP addresses except for below" should be enabled and IANA RFC 1918 option should be enabled in the exceptions section (Screenshot included). - [@Kaushik Biswas](mailto:kaushik.biswas@keysight.com) checked that it is already available in current deployment. 
 
On AWS Env (Fixes)
3. Change the Malware domains strict order rule group to be run in "Alert mode" (Screenshot attached). The reason is - recently AWS updated this rule group and its blocking background traffic due to URL. - [@Kaushik Biswas](mailto:kaushik.biswas@keysight.com)