### PR TITLE
Deploy CyPerf Controller and Agents with CyPerf 7.0 marketplace image 

### DIFF
--- a/terraform/modules/aws_agent/main.tf
+++ b/terraform/modules/aws_agent/main.tf
@@ -43,6 +43,10 @@ data "aws_ami" "agent_ami" {
       name   = "product-code"
       values = [var.agent_product_code]
     }
+    filter {
+      name   = "name"
+      values = ["*7-0-3-807*"]
+    }
 }
 
 resource "aws_instance" "aws_cli_agent" {

--- a/terraform/modules/aws_mdw/main.tf
+++ b/terraform/modules/aws_mdw/main.tf
@@ -23,6 +23,10 @@ data "aws_ami" "mdw_ami" {
       name   = "product-code"
       values = [var.mdw_product_code]
     }
+    filter {
+      name   = "name"
+      values = ["*1-0-14934*"]
+    }
 }
 
 resource "aws_eip" "mdw_public_ip" {


### PR DESCRIPTION
Terraform deployment script was pointing to latest CyPerf Marketplace image . With this PR, deployment always point to CyPerf 7.0 Marketplace image for aws.